### PR TITLE
bugfix quickChoice isCards

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Follow this set of instructions if you want to deploy the components to your pro
 
 1. Click links from the table to install the managed packages in your org.
 
-   Disclaimer: these packages haven't gone through security review yet but that is our plan for the future.
+    Disclaimer: these packages haven't gone through security review yet but that is our plan for the future.
 
 | Package Name           | Install Link                                                                                                                               | Documentation Link                                                                                  |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -52,8 +52,8 @@
         {
             "path": "src-ui",
             "package": "AC - UI",
-            "versionName": "ver 0.2",
-            "versionNumber": "0.2.0.NEXT",
+            "versionName": "ver 0.3",
+            "versionNumber": "0.3.0.NEXT",
             "default": false
         },
         {

--- a/src-ui/main/default/lwc/quickChoice/quickChoice.js
+++ b/src-ui/main/default/lwc/quickChoice/quickChoice.js
@@ -73,7 +73,7 @@ export default class QuickChoice extends LightningElement {
                 : new Array(data.values.length);
             // Load values from picklist field
             let options;
-            if (this.isCards) {
+            if (this.isCards()) {
                 // Keep labels empty for cards since values === labels
                 options = data.values.map((option, index) => ({
                     value: option.value,
@@ -88,7 +88,7 @@ export default class QuickChoice extends LightningElement {
             }
             // Add a 'none' option when selection is not required
             if (!this.required) {
-                if (this.isCards) {
+                if (this.isCards()) {
                     options.unshift({
                         label: '-- None --',
                         value: '',


### PR DESCRIPTION
lines 76 and 91 refer to method isCards() without parenthesis, leading it to be interpreted as a property. This leads to the component not correctly setting the option object correctly and displaying no labels for the corresponding values when configured to retrieve labels/values from a picklist field.

Fixed by changing 

`if (this.isCards) {`

on each of those lines to

`if (this.isCards()) {`

