### PR TITLE
Correct typo in helper function call

### DIFF
--- a/src-ui/main/default/aura/navigate/navigateController.js
+++ b/src-ui/main/default/aura/navigate/navigateController.js
@@ -23,7 +23,7 @@
                 break;
 
             case 'namedpage':
-                pageReference = helper.getNamePageReference(component);
+                pageReference = helper.getNamedPageReference(component);
                 break;
 
             case 'tab':


### PR DESCRIPTION
Line 26 was "pageReference = helper.getNamePageReference(component);". This should read "pageReference = helper.getNamedPageReference(component);" to match the name of the helper function

### What does this PR do?
Corrects a typo

### What issues does this PR fix or reference?
Error Occurred: Action failed: autocomp:navigate$controller$invoke [helper.getNamePageReference is not a function]

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

Error message

### Functionality After

Navigate to a Named Page Reference