### PR TITLE
Made QuickChoice Record Type Id optional

### DIFF
--- a/src-ui/main/default/lwc/quickChoicePropertyEditor/quickChoicePropertyEditor.html
+++ b/src-ui/main/default/lwc/quickChoicePropertyEditor/quickChoicePropertyEditor.html
@@ -61,7 +61,6 @@
                 value-type={recordTypeIdValueType}
                 builder-context={builderContext}
                 onvaluechanged={handleValueChanged}
-                required
             ></c-flow-combobox>
         </div>
     </template>


### PR DESCRIPTION
QuickChoice Record Type Id is optional in the root component but the CPE is set to required, changing CPE element to actually make Record Type Id optional.
