### PR TITLE
feat: remove duplicates and join

### DIFF
--- a/src-collections/main/default/classes/ExtractStringsFromRecords.cls
+++ b/src-collections/main/default/classes/ExtractStringsFromRecords.cls
@@ -31,9 +31,16 @@ global with sharing class ExtractStringsFromRecords {
             String fieldValue = String.valueOf(record.get(fieldName));
             values.add(fieldValue);
         }
+        // Remove duplicates
+        if (input.removeDuplicates) {
+            values = new List<String>(new Set<String>(values));
+        }
+        // Join values
+        String joinedValues = String.join(values, input.joinDelimiter);
         // Return output
         OutputParameters output = new OutputParameters();
         output.values = values;
+        output.joinedValues = joinedValues;
         return output;
     }
 
@@ -45,16 +52,19 @@ global with sharing class ExtractStringsFromRecords {
         global List<SObject> collection;
         @InvocableVariable(required=true)
         global String fieldName;
+        @InvocableVariable(label='Remove duplicates')
+        global Boolean removeDuplicates = false;
+        @InvocableVariable(label='Join delimiter')
+        global String joinDelimiter = ',';
     }
 
     /**
      * Wrapper class for output parameters
      */
     global class OutputParameters {
-        global OutputParameters() {
-            values = new List<String>();
-        }
         @InvocableVariable
         global List<String> values;
+        @InvocableVariable
+        global String joinedValues;
     }
 }

--- a/src-collections/test/default/classes/ExtractStringsFromRecordsTests.cls
+++ b/src-collections/test/default/classes/ExtractStringsFromRecordsTests.cls
@@ -1,10 +1,27 @@
 @isTest(isParallel=true)
 global class ExtractStringsFromRecordsTests {
+    private static final List<Account> SAMPLE_ACCOUNTS = new List<Account>{
+        new Account(Name = 'A1', AccountNumber = 'A'),
+        new Account(Name = 'A2', AccountNumber = 'A'),
+        new Account(Name = 'B1', AccountNumber = 'B')
+    };
+
+    private static final List<String> ACCOUNT_NUMBERS = new List<String>{
+        'A',
+        'A',
+        'B'
+    };
+    private static final List<String> UNIQUE_ACCOUNT_NUMBERS = new List<String>{
+        'A',
+        'B'
+    };
+    private static final String DELIMITER = '-TEST-';
+
     @isTest
-    global static void bulkInvoke_works() {
+    global static void bulkInvoke_works_with_duplicates() {
         ExtractStringsFromRecords.InputParameters input = new ExtractStringsFromRecords.InputParameters();
-        input.collection = SampleDataFactory.SAMPLE_ACCOUNTS;
-        input.fieldName = 'Name';
+        input.collection = SAMPLE_ACCOUNTS;
+        input.fieldName = 'AccountNumber';
         List<ExtractStringsFromRecords.InputParameters> inputs = new List<ExtractStringsFromRecords.InputParameters>{
             input
         };
@@ -13,12 +30,47 @@ global class ExtractStringsFromRecordsTests {
             inputs
         );
 
-        System.assertEquals(inputs.size(), outputs.size());
+        System.assertEquals(ACCOUNT_NUMBERS, outputs[0].values);
         System.assertEquals(
-            SampleDataFactory.SAMPLE_ACCOUNTS.size(),
-            outputs[0].values.size()
+            String.join(ACCOUNT_NUMBERS, ','),
+            outputs[0].joinedValues
         );
-        String value = outputs[0].values[0];
-        System.assertEquals(SampleDataFactory.ACCOUNT_NAME + 1, value);
+    }
+
+    @isTest
+    global static void bulkInvoke_works_without_duplicates() {
+        ExtractStringsFromRecords.InputParameters input = new ExtractStringsFromRecords.InputParameters();
+        input.collection = SAMPLE_ACCOUNTS;
+        input.fieldName = 'AccountNumber';
+        input.removeDuplicates = true;
+        List<ExtractStringsFromRecords.InputParameters> inputs = new List<ExtractStringsFromRecords.InputParameters>{
+            input
+        };
+
+        List<ExtractStringsFromRecords.OutputParameters> outputs = ExtractStringsFromRecords.bulkInvoke(
+            inputs
+        );
+
+        System.assertEquals(UNIQUE_ACCOUNT_NUMBERS, outputs[0].values);
+    }
+
+    @isTest
+    global static void bulkInvoke_works_with_custom_delimiter() {
+        ExtractStringsFromRecords.InputParameters input = new ExtractStringsFromRecords.InputParameters();
+        input.collection = SAMPLE_ACCOUNTS;
+        input.fieldName = 'AccountNumber';
+        input.joinDelimiter = DELIMITER;
+        List<ExtractStringsFromRecords.InputParameters> inputs = new List<ExtractStringsFromRecords.InputParameters>{
+            input
+        };
+
+        List<ExtractStringsFromRecords.OutputParameters> outputs = ExtractStringsFromRecords.bulkInvoke(
+            inputs
+        );
+
+        System.assertEquals(
+            String.join(ACCOUNT_NUMBERS, DELIMITER),
+            outputs[0].joinedValues
+        );
     }
 }


### PR DESCRIPTION
Added two features to `ExtractStringsFromRecords`:
- remove duplicates values
- join result values as a string with a custom delimiter